### PR TITLE
fix autotools build on windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,10 +32,15 @@ dnl AM_CONDITIONAL(DARWIN, test x$os = xdarwin)
 
 
 dnl The file containing the operating system dependent disc access code.
-DISC_OS_OBJ=disc_${os}.lo
+if test "${os}" = "win32"; then
+  DISC_OS_OBJ="disc_${os}.lo disc_${os}_new.lo"
+  AC_MSG_NOTICE([using discid implementation disc_${os}.c disc_${os}_new.c])
+else
+  DISC_OS_OBJ="disc_${os}.lo"
+  AC_MSG_NOTICE([using discid implementation disc_${os}.c])
+fi
 AC_SUBST(DISC_OS_OBJ)
 
-AC_MSG_NOTICE([using discid implementation disc_${os}.c])
 
 
 dnl Checks for programs.


### PR DESCRIPTION
Like already done for cmake,
we need to add disc_win32_new.lo to the objects to build
with the autotools on Windows.

Tested with
./autogen.sh; ./configure; make; make install
on Cygwin and MinGW (both on a virtual WinXP)

cygwin output: cygdiscid-0.dll
mingw output: libdiscid-0.dll
