### PR TITLE
Ship src/disc_generic.c

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,7 +23,8 @@ lib_LTLIBRARIES = libdiscid.la
 libdiscid_la_SOURCES = base64.c sha1.c disc.c
 EXTRA_libdiscid_la_SOURCES = \
 	disc_linux.c disc_win32.c disc_win32_new.c \
-	disc_darwin.c disc_freebsd.c disc_solaris.c disc_openbsd.c
+	disc_darwin.c disc_freebsd.c disc_solaris.c disc_openbsd.c \
+	disc_generic.c
 
 AM_CPPFLAGS = -I$(top_srcdir)/include
 libdiscid_la_LIBADD = @DISC_OS_OBJ@


### PR DESCRIPTION
src/disc_generic.c is missing from the tarball, so add disc_generic.c to src/Makefile.am's EXTRA_libdiscid_la_SOURCES. Provided the released tarball is built with automake's make dist this should do the trick.
