### PR TITLE
Hide internal symbols on Linux/Unix

### DIFF
--- a/include/discid/discid.h
+++ b/include/discid/discid.h
@@ -30,8 +30,18 @@
 #	else
 #		define LIBDISCID_API __declspec(dllimport)
 #	endif
+#	define LIBDISCID_INTERNAL
 #else
-#	define LIBDISCID_API
+#	if (defined(__GNUC__) && (__GNUC__ >= 4)) || defined(__clang__)
+#		define LIBDISCID_API
+#		define LIBDISCID_INTERNAL __attribute__((visibility("hidden")))
+#	elif defined(__SUNPRO_C)
+#		define LIBDISCID_API __global
+#		define LIBDISCID_API __hidden
+#	else
+#		define LIBDISCID_API
+#		define LIBDISCID_INTERNAL
+#	endif
 #endif
 
 

--- a/include/discid/discid_private.h
+++ b/include/discid/discid_private.h
@@ -88,7 +88,7 @@ typedef struct {
  *
  * On error, 0 is returned. On success, 1 is returned.
  */
-int mb_disc_read_unportable(mb_disc_private *disc, const char *device, unsigned int features);
+LIBDISCID_INTERNAL int mb_disc_read_unportable(mb_disc_private *disc, const char *device, unsigned int features);
 
 
 /*
@@ -96,12 +96,12 @@ int mb_disc_read_unportable(mb_disc_private *disc, const char *device, unsigned 
  * on this operating system. It has to be in a format usable for the second
  * parameter of mb_disc_read_unportable().
  */
-char *mb_disc_get_default_device_unportable(void);
+LIBDISCID_INTERNAL char *mb_disc_get_default_device_unportable(void);
 
 /*
  * This should return 1 if the feature is supported by the platform
  * and 0 if not.
  */
-int mb_disc_has_feature_unportable(enum discid_feature feature);
+LIBDISCID_INTERNAL int mb_disc_has_feature_unportable(enum discid_feature feature);
 
 #endif /* MUSICBRAINZ_DISC_ID_PRIVATE_H */

--- a/src/base64.h
+++ b/src/base64.h
@@ -67,6 +67,8 @@
 #ifndef BASE64_H
 #define BASE64_H
 
-unsigned char *rfc822_binary (void *src,unsigned long srcl,unsigned long *len);
+#include "discid/discid.h" /* for LIBDISCID_INTERNAL */
+
+LIBDISCID_INTERNAL unsigned char *rfc822_binary (void *src,unsigned long srcl,unsigned long *len);
 
 #endif

--- a/src/sha1.h
+++ b/src/sha1.h
@@ -10,6 +10,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include "discid/discid.h" /* for LIBDISCID_INTERNAL */
 
 /* Useful defines & typedefs */
 typedef unsigned char SHA_BYTE;	/* 8-bit quantity */
@@ -25,13 +26,13 @@ typedef struct {
     int local;			/* unprocessed amount in data */
 } SHA_INFO;
 
-void sha_init(SHA_INFO *);
-void sha_update(SHA_INFO *, SHA_BYTE *, int);
-void sha_final(unsigned char [20], SHA_INFO *);
+LIBDISCID_INTERNAL void sha_init(SHA_INFO *);
+LIBDISCID_INTERNAL void sha_update(SHA_INFO *, SHA_BYTE *, int);
+LIBDISCID_INTERNAL void sha_final(unsigned char [20], SHA_INFO *);
 
-void sha_stream(unsigned char [20], SHA_INFO *, FILE *);
-void sha_print(unsigned char [20]);
-char *sha_version(void);
+LIBDISCID_INTERNAL void sha_stream(unsigned char [20], SHA_INFO *, FILE *);
+LIBDISCID_INTERNAL void sha_print(unsigned char [20]);
+LIBDISCID_INTERNAL char *sha_version(void);
 
 #define SHA_VERSION 1
 


### PR DESCRIPTION
With gcc, clang and other compilers, symbols are exported per default. The
symbols in discid_private.h, sha1.h and base64.h are for internal use only, so
they are hidden from now on.

Signed-off-by: Sebastian Ramacher sramacher@debian.org
