### PR TITLE
Provide automatically generated version.h file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ config.h
 versioninfo.rc
 libdiscid.pc
 docs/
+include/discid/version.h
 
 # Autotools files
 configure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ SET(libdir ${LIB_INSTALL_DIR})
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/libdiscid.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libdiscid.pc)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/versioninfo.rc.in ${CMAKE_CURRENT_BINARY_DIR}/versioninfo.rc)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile)
-
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/include/discid/version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/include/discid/version.h)
 
 # normalizing operating systems
 IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
@@ -102,7 +102,7 @@ TARGET_LINK_LIBRARIES(test_discid libdiscid)
 
 INSTALL(TARGETS libdiscid DESTINATION ${LIB_INSTALL_DIR})
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/libdiscid.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
-INSTALL(FILES include/discid/discid.h DESTINATION ${INCLUDE_INSTALL_DIR}/discid)
+INSTALL(FILES include/discid/discid.h include/discid/version.h DESTINATION ${INCLUDE_INSTALL_DIR}/discid)
 
 
 ADD_CUSTOM_TARGET(docs doxygen)

--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,10 @@ AC_SUBST(libdiscid_VERSION)
 AC_SUBST(libdiscid_VERSION_LT)
 AC_SUBST(libdiscid_VERSION_RC)
 
+AC_SUBST(libdiscid_MAJOR)
+AC_SUBST(libdiscid_MINOR)
+AC_SUBST(libdiscid_PATCH)
+
 dnl Set the host_cpu, host_vendor, and host_os variables.
 AC_CANONICAL_HOST
 
@@ -87,4 +91,5 @@ fi
 AC_OUTPUT([
   Makefile src/Makefile include/Makefile include/discid/Makefile
   examples/Makefile test/Makefile libdiscid.pc versioninfo.rc Doxyfile
+  include/discid/version.h
 ])

--- a/include/discid/Makefile.am
+++ b/include/discid/Makefile.am
@@ -20,6 +20,6 @@
 #    $Id$
 #
 discid_incdir = $(includedir)/discid
-discid_inc_HEADERS = discid.h
+discid_inc_HEADERS = discid.h version.h
 
 EXTRA_DIST = discid_private.h

--- a/include/discid/discid.h
+++ b/include/discid/discid.h
@@ -24,6 +24,8 @@
 #ifndef MUSICBRAINZ_DISC_ID_H
 #define MUSICBRAINZ_DISC_ID_H
 
+#include "version.h"
+
 #if (defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__))
 #	ifdef libdiscid_EXPORTS
 #		define LIBDISCID_API __declspec(dllexport)

--- a/include/discid/version.h.in
+++ b/include/discid/version.h.in
@@ -1,0 +1,11 @@
+/* automatically generated file containing version information about
+   libdiscid */
+
+#ifndef MUSICBRAINZ_DISC_ID_VERSION_H
+#define MUSICBRAINZ_DISC_ID_VERSION_H
+
+#define DISCID_VERSION_MAJOR @libdiscid_MAJOR@
+#define DISCID_VERSION_MINOR @libdiscid_MINOR@
+#define DISCID_VERSION_PATCH @libdiscid_PATCH@
+
+#endif


### PR DESCRIPTION
I still think that it be nice to have the version defined in a header file. This commit adds an version.h that is automatically generated by auto*/cmake.
