### PR TITLE
Ignore .dirstamp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ examples/discid
 *.lo
 *.o
 *.la
+.dirstamp


### PR DESCRIPTION
The autotools build system now produces .dirstamp files.
