### PR TITLE
LIB-40: Mark discid_get_webservice_url as deprecated

### DIFF
--- a/include/discid/discid.h.in
+++ b/include/discid/discid.h.in
@@ -42,7 +42,9 @@
 #	define LIBDISCID_INTERNAL
 #endif
 
-#if (defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))) || defined(__clang__)
+#if (defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__))
+#define LIBDISCID_DEPRECATED __declspec(deprecated)
+#elif (defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))) || defined(__clang__)
 #define LIBDISCID_DEPRECATED __attribute__((deprecated))
 #else
 #define LIBDISCID_DEPRECATED


### PR DESCRIPTION
There appears to be a __declspec(deprecated) in Visual Studio. But I can' test that so I haven't added it.

EDIT by JonnyJD:
http://tickets.musicbrainz.org/browse/LIB-40
