### PR TITLE
LIB-43: Use first CD drive letter on Windows as default device

### DIFF
--- a/src/disc_win32.c
+++ b/src/disc_win32.c
@@ -131,14 +131,16 @@ static void read_disc_isrc(HANDLE hDevice, mb_disc_private *disc, int track)
 }
 
 char *mb_disc_get_default_device_unportable(void) {
-	DWORD mask = GetLogicalDrives();
 	int i;
-
+	char device[MAX_DEV_LEN];
+	DWORD mask = GetLogicalDrives();
+	
 	for (i = 0; i <= 25; i++) {
 		if (mask >> i & 1) {
-			snprintf(default_device, MAX_DEV_LEN, "%c:", i + 'A');
+			snprintf(device, MAX_DEV_LEN, "%c:", i + 'A');
 			
-			if (GetDriveType(default_device) == DRIVE_CDROM) {
+			if (GetDriveType(device) == DRIVE_CDROM) {
+				strncpy(default_device, device, MAX_DEV_LEN);
 				return default_device;
 			}
 		}


### PR DESCRIPTION
Currently if the default device is used on Windows it tries to access the hardcoded drive "D:". The patch uses the first CD drive instead.

The code is completely stolen from Picard (https://github.com/musicbrainz/picard/blob/master/picard/util/cdrom.py#L33), I just translated it back to C.

EDIT by JonnyJD:
tracked with http://tickets.musicbrainz.org/browse/LIB-43
EDIT by JonnyJD:
updated title to match ticket title
