### PR TITLE
data-tracks improvements: generalize mb_disc_read_unportabl

### DIFF
--- a/src/disc_darwin.c
+++ b/src/disc_darwin.c
@@ -113,7 +113,7 @@ static kern_return_t get_device_file_path( io_iterator_t mediaIterator, char *de
     return kernResult;
 }
 
-static void read_disc_mcn(int fd, mb_disc_private *disc)
+void mb_disc_unix_read_mcn(int fd, mb_disc_private *disc)
 {
     dk_cd_read_mcn_t cd_read_mcn;
     bzero(&cd_read_mcn, sizeof(cd_read_mcn));
@@ -125,7 +125,7 @@ static void read_disc_mcn(int fd, mb_disc_private *disc)
     }
 }
 
-static void read_disc_isrc(int fd, mb_disc_private *disc, int track)
+void mb_disc_unix_read_isrc(int fd, mb_disc_private *disc, int track)
 {
     dk_cd_read_isrc_t	cd_read_isrc;
     bzero(&cd_read_isrc, sizeof(cd_read_isrc));
@@ -230,35 +230,5 @@ int mb_disc_unix_read_toc_header(int fd, mb_disc_toc *mb_toc) {
 
 int mb_disc_unix_read_toc_entry(int fd, int track_num, mb_disc_toc_track *toc) {
 	/* On Darwin the tracks are already filled along with the header */
-	return 1;
-}
-
-int mb_disc_read_unportable(mb_disc_private *disc, const char *device, unsigned int features) 
-{
-	mb_disc_toc toc;
-	int fd;
-	int i;
-
-	if (!mb_disc_unix_read_toc(disc, &toc, device)) 
-		return 0;
-	if (!mb_disc_load_toc(disc, &toc))
-		return 0;
-
-	fd = mb_disc_unix_open(disc, device);
-  
-	// Read in the media catalogue number
-	if (features & DISCID_FEATURE_MCN) {
-		read_disc_mcn(fd, disc);
-	}
-
-	for (i = disc->first_track_num; i <= disc->last_track_num; i++) {
-		// Read in the IRSC codes for tracks
-		if (features & DISCID_FEATURE_ISRC) {
-			read_disc_isrc(fd, disc, i);
-		}
-	}
-
-	close(fd);
-  
 	return 1;
 }

--- a/src/disc_freebsd.c
+++ b/src/disc_freebsd.c
@@ -81,6 +81,13 @@ int mb_disc_unix_read_toc_entry(int fd, int track_num, mb_disc_toc_track *track)
 	return 1;
 }
 
+void mb_disc_unix_read_mcn(int fd, mb_disc_private *disc) {
+	return;
+}
+
+void mb_disc_unix_read_isrc(int fd, mb_disc_private *disc, int track_num) {
+	return;
+}
 
 char *mb_disc_get_default_device_unportable(void) {
 	return MB_DEFAULT_DEVICE;
@@ -93,20 +100,6 @@ int mb_disc_has_feature_unportable(enum discid_feature feature) {
 		default:
 			return 0;
 	}
-}
-
-
-int mb_disc_read_unportable(mb_disc_private *disc, const char *device,
-			    unsigned int features) {
-	mb_disc_toc toc;
-
-	if ( !mb_disc_unix_read_toc(disc, &toc, device) )
-		return 0;
-
-	if ( !mb_disc_load_toc(disc, &toc) )
-		return 0;
-
-	return 1;
 }
 
 /* EOF */

--- a/src/disc_linux.c
+++ b/src/disc_linux.c
@@ -89,7 +89,7 @@ char *mb_disc_get_default_device_unportable(void) {
 	return MB_DEFAULT_DEVICE;
 }
 
-static void read_disc_mcn(int fd, mb_disc_private *disc)
+void mb_disc_unix_read_mcn(int fd, mb_disc_private *disc)
 {
 	struct cdrom_mcn mcn;
 
@@ -131,7 +131,7 @@ static int scsi_cmd(int fd, unsigned char *cmd, int cmd_len,
 	}
 }
 
-static void read_track_isrc(int fd, mb_disc_private *disc, int track_num) {
+void mb_disc_unix_read_isrc(int fd, mb_disc_private *disc, int track_num) {
 	int i;
 	unsigned char cmd[10];
 	unsigned char data[24];
@@ -171,7 +171,6 @@ static void read_track_isrc(int fd, mb_disc_private *disc, int track_num) {
 		strncpy(disc->isrc[track_num], buffer, ISRC_STR_LENGTH);
 	}
 	/* data[21:23] = zero, AFRAME, reserved */
-
 }
 
 int mb_disc_has_feature_unportable(enum discid_feature feature) {
@@ -183,38 +182,6 @@ int mb_disc_has_feature_unportable(enum discid_feature feature) {
 		default:
 			return 0;
 	}
-}
-
-
-int mb_disc_read_unportable(mb_disc_private *disc, const char *device,
-			    unsigned int features) {
-	mb_disc_toc toc;
-	int fd;
-	int i;
-
-	if ( !mb_disc_unix_read_toc(disc, &toc, device) )
-		return 0;
-
-	if ( !mb_disc_load_toc(disc, &toc) )
-		return 0;
-
-	fd = mb_disc_unix_open(disc, device);
-
-	/* Read in the media catalog number */
-	if (features & DISCID_FEATURE_MCN) {
-		read_disc_mcn(fd, disc);
-	}
-
-	for (i = disc->first_track_num; i <= disc->last_track_num; i++) {
-		/* Read the ISRC for the track */
-		if (features & DISCID_FEATURE_ISRC) {
-			read_track_isrc(fd, disc, i);
-		}
-	}
-
-	close(fd);
-
-	return 1;
 }
 
 /* EOF */

--- a/src/disc_netbsd.c
+++ b/src/disc_netbsd.c
@@ -86,6 +86,13 @@ int mb_disc_unix_read_toc_entry(int fd, int track_num, mb_disc_toc_track *track)
 	return 1;
 }
 
+void mb_disc_unix_read_mcn(int fd, mb_disc_private *disc) {
+	return;
+}
+
+void mb_disc_unix_read_isrc(int fd, mb_disc_private *disc, int track_num) {
+	return;
+}
 
 int mb_disc_has_feature_unportable(enum discid_feature feature) {
 	switch(feature) {
@@ -94,18 +101,4 @@ int mb_disc_has_feature_unportable(enum discid_feature feature) {
 		default:
 			return 0;
 	}
-}
-
-
-int mb_disc_read_unportable(mb_disc_private *disc, const char *device,
-			    unsigned int features) {
-	mb_disc_toc toc;
-
-	if ( !mb_disc_unix_read_toc(disc, &toc, device) )
-		return 0;
-
-	if ( !mb_disc_load_toc(disc, &toc) )
-		return 0;
-
-	return 1;
 }

--- a/src/disc_solaris.c
+++ b/src/disc_solaris.c
@@ -76,6 +76,13 @@ int mb_disc_unix_read_toc_entry(int fd, int track_num, mb_disc_toc_track *track)
 	return ret;
 }
 
+void mb_disc_unix_read_mcn(int fd, mb_disc_private *disc) {
+	return;
+}
+
+void mb_disc_unix_read_isrc(int fd, mb_disc_private *disc, int track_num) {
+	return;
+}
 
 char *mb_disc_get_default_device_unportable(void) {
 	return MB_DEFAULT_DEVICE;
@@ -88,20 +95,6 @@ int mb_disc_has_feature_unportable(enum discid_feature feature) {
 		default:
 			return 0;
 	}
-}
-
-
-int mb_disc_read_unportable(mb_disc_private *disc, const char *device,
-			    unsigned int features) {
-	mb_disc_toc toc;
-
-	if ( !mb_disc_unix_read_toc(disc, &toc, device) )
-		return 0;
-
-	if ( !mb_disc_load_toc(disc, &toc) )
-		return 0;
-
-	return 1;
 }
 
 /* EOF */

--- a/src/toc.c
+++ b/src/toc.c
@@ -36,7 +36,7 @@
 
 
 int mb_disc_load_toc(mb_disc_private *disc, mb_disc_toc *toc)  {
-	int first_audio_track, last_audio_track, data_tracks, i;
+	int first_audio_track, last_audio_track, i;
 	mb_disc_toc_track *track;
 
 	if (toc->first_track_num < 1) {
@@ -56,13 +56,10 @@ int mb_disc_load_toc(mb_disc_private *disc, mb_disc_toc *toc)  {
 	 */
 	first_audio_track = toc->first_track_num;
 	last_audio_track = -1;
-	data_tracks = 0;
 	/* scan the TOC for audio tracks */
 	for (i = toc->first_track_num; i <= toc->last_track_num; i++) {
 		track = &toc->tracks[i];
-		if ( track->control & DATA_TRACK ) {
-			data_tracks += 1;
-		} else {
+		if ( !(track->control & DATA_TRACK) ) {
 			last_audio_track = i;
 		}
 	}

--- a/src/unix.c
+++ b/src/unix.c
@@ -45,11 +45,8 @@ int mb_disc_unix_open(mb_disc_private *disc, const char *device) {
 	}
 }
 
-int mb_disc_unix_read_toc(mb_disc_private *disc, mb_disc_toc *toc, const char *device) {
-	int fd;
+int mb_disc_unix_read_toc(int fd, mb_disc_private *disc, mb_disc_toc *toc) {
 	int i;
-
-	fd = mb_disc_unix_open(disc, device);
 
 	/* Find the numbers of the first track (usually 1) and the last track. */
 	if ( !mb_disc_unix_read_toc_header(fd, toc) ) {
@@ -75,8 +72,6 @@ int mb_disc_unix_read_toc(mb_disc_private *disc, mb_disc_toc *toc, const char *d
 	}
 	mb_disc_unix_read_toc_entry(fd, 0xAA, &toc->tracks[0]);
 
-	close(fd);
-
 	return 1;
 }
 
@@ -86,13 +81,13 @@ int mb_disc_read_unportable(mb_disc_private *disc, const char *device,
 	int fd;
 	int i;
 
-	if ( !mb_disc_unix_read_toc(disc, &toc, device) )
+	fd = mb_disc_unix_open(disc, device);
+
+	if ( !mb_disc_unix_read_toc(fd, disc, &toc) )
 		return 0;
 
 	if ( !mb_disc_load_toc(disc, &toc) )
 		return 0;
-
-	fd = mb_disc_unix_open(disc, device);
 
 	/* Read in the media catalog number */
 	if (features & DISCID_FEATURE_MCN

--- a/src/unix.h
+++ b/src/unix.h
@@ -55,8 +55,7 @@ LIBDISCID_INTERNAL void mb_disc_unix_read_isrc(int fd, mb_disc_private *disc, in
  * This function is implemented in unix.c and can be used
  * after the above functions are implemented on the platform.
  */
-LIBDISCID_INTERNAL int mb_disc_unix_read_toc(mb_disc_private *disc, mb_disc_toc *toc,
-			  const char *device);
+LIBDISCID_INTERNAL int mb_disc_unix_read_toc(int fd, mb_disc_private *disc, mb_disc_toc *toc);
 
 /*
  * utility function to try opening the device with open()

--- a/src/unix.h
+++ b/src/unix.h
@@ -37,6 +37,19 @@ LIBDISCID_INTERNAL int mb_disc_unix_read_toc_header(int fd, mb_disc_toc *toc);
  */
 LIBDISCID_INTERNAL int mb_disc_unix_read_toc_entry(int fd, int track_num, mb_disc_toc_track *track);
 
+/*
+ * Read the MCN from the disc
+ *
+ * THIS FUNCTION HAS TO BE IMPLEMENTED FOR THE PLATFORM
+ */
+LIBDISCID_INTERNAL void mb_disc_unix_read_mcn(int fd, mb_disc_private *disc);
+
+/*
+ * Read the ISRC for a certain track from disc
+ *
+ * THIS FUNCTION HAS TO BE IMPLEMENTED FOR THE PLATFORM
+ */
+LIBDISCID_INTERNAL void mb_disc_unix_read_isrc(int fd, mb_disc_private *disc, int track_num);
 
 /*
  * This function is implemented in unix.c and can be used

--- a/src/unix.h
+++ b/src/unix.h
@@ -28,24 +28,24 @@
  *
  * THIS FUNCTION HAS TO BE IMPLEMENTED FOR THE PLATFORM
  */
-int mb_disc_unix_read_toc_header(int fd, mb_disc_toc *toc);
+LIBDISCID_INTERNAL int mb_disc_unix_read_toc_header(int fd, mb_disc_toc *toc);
 
 /*
  * Read a TOC entry for a certain track from disc
  *
  * THIS FUNCTION HAS TO BE IMPLEMENTED FOR THE PLATFORM
  */
-int mb_disc_unix_read_toc_entry(int fd, int track_num, mb_disc_toc_track *track);
+LIBDISCID_INTERNAL int mb_disc_unix_read_toc_entry(int fd, int track_num, mb_disc_toc_track *track);
 
 
 /*
  * This function is implemented in unix.c and can be used
  * after the above functions are implemented on the platform.
  */
-int mb_disc_unix_read_toc(mb_disc_private *disc, mb_disc_toc *toc,
+LIBDISCID_INTERNAL int mb_disc_unix_read_toc(mb_disc_private *disc, mb_disc_toc *toc,
 			  const char *device);
 
 /*
  * utility function to try opening the device with open()
  */
-int mb_disc_unix_open(mb_disc_private *disc, const char *device);
+LIBDISCID_INTERNAL int mb_disc_unix_open(mb_disc_private *disc, const char *device);


### PR DESCRIPTION
This is a suggestion for the current data-tracks branch. It introduces a common Unix implementation for `mb_disc_read_unportable` again by providing additional platform sepcifc methods `mb_disc_unix_read_mcn` and `mb_disc_unix_read_isrc`.

This has the advantage of avoiding code duplication for `mb_disc_read_unportable` and simplifies the platform specific implementation. The downside is that those two additional functions must be implemented in the platform specifc code even if the respective features are unsupported. But an empty implementation will do.

I have not yet tested this on any platform but Linux, but I would like to get opinions on the general idea before doing any platform testing.
