### PR TITLE
LIB-44: pre-read the TOC

### DIFF
--- a/src/disc.c
+++ b/src/disc.c
@@ -151,6 +151,14 @@ int discid_read_sparse(DiscId *d, const char *device, unsigned int features) {
 	/* Necessary, because the disc handle could have been used before. */
 	memset(disc, 0, sizeof(mb_disc_private));
 
+	/* pre-read the TOC to reduce "not-ready" problems
+	 * See LIB-44 (issues with multi-session discs)
+	 */
+	if (!mb_disc_read_unportable(disc, device, DISCID_FEATURE_READ)) {
+		return 0;
+	}
+	memset(disc, 0, sizeof(mb_disc_private));
+
 	return disc->success = mb_disc_read_unportable(disc, device, features);
 }
 


### PR DESCRIPTION
Multi-disc releases sometimes give different disc IDs only for the first
read right after inserting the disc in the drive.
Reading the TOC (and only that part) twice should reduce
the chance that this happens.

EDIT:
http://tickets.musicbrainz.org/browse/LIB-44
