### PR TITLE
discid: also display track durations in minutes and seconds

### DIFF
--- a/examples/discid.c
+++ b/examples/discid.c
@@ -26,12 +26,51 @@
 #define discid_read_sparse(disc, dev, i) discid_read(disc, dev)
 #endif
 
-#define FRAMES_PER_SECOND 75.0
+#define SECTORS_PER_SECOND 75
+
+/* Convert a number of sectors to a human-readable time in hours,minutes,seconds
+ * If round is true, seconds will be rounded to nearest,
+ * else 1/100 seconds time precision is used.
+ * If duration is over one hour, hours will be added in front of the string
+ * Examples:
+ *  33284 sectors with round=0 -> ( 7:23.79)
+ *  33284 sectors with round=1 -> ( 7:24)
+ * 356163 sectors with round=1 -> ( 1:19:09)
+ * 356163 sectors with round=0 -> ( 1:19:08.84)
+ *
+ * Result is written to buf
+ */
+void sectors_to_time(int sectors, int round, char *buf, size_t bufsize) {
+	float duration_in_secs = (float) sectors / SECTORS_PER_SECOND;
+	float subsecond = duration_in_secs - (int) duration_in_secs;
+	int hours = duration_in_secs / 3600;
+	int minutes = (duration_in_secs - hours * 3600) / 60;
+	float seconds = duration_in_secs - (hours * 3600 + minutes * 60);
+
+	if (round) {
+		int seconds_rounded = seconds;
+
+		if (subsecond >= 0.5) seconds_rounded++;
+		if (hours > 0)
+			snprintf(buf, bufsize, "%2d:%02d:%02d", hours, minutes, seconds_rounded);
+		else
+			snprintf(buf, bufsize, "%2d:%02d", minutes, seconds_rounded);
+	}
+	else {
+		if (hours > 0)
+			snprintf(buf, bufsize, "%2d:%02d:%05.2f", hours, minutes, seconds);
+		else
+			snprintf(buf, bufsize, "%2d:%05.2f", minutes, seconds);
+	}
+}
 
 int main(int argc, char *argv[]) {
 	DiscId *disc = discid_new();
 	int i, first_track, last_track;
 	char *device = NULL;
+	char time[14];
+	int sectors;
+	int rounded_seconds = 0;
 
 	/* If we have an argument, use it as the device name */
 	if (argc > 1) {
@@ -52,17 +91,17 @@ int main(int argc, char *argv[]) {
 	printf("First track   : %d\n", first_track);
 	printf("Last track    : %d\n", last_track);
 
-	printf("Length        : %d frames\n", discid_get_sectors(disc));
+	sectors = discid_get_sectors(disc);
+	sectors_to_time(sectors, rounded_seconds, time, sizeof(time));
+	printf("Length        : %d sectors (%s)\n", sectors, time);
 
 	for ( i = first_track; i <= last_track; i++ ) {
-		int frames = discid_get_track_length(disc, i);
-		float duration_in_secs = (float) frames / FRAMES_PER_SECOND;
-		int minutes = duration_in_secs / 60;
-		float seconds = duration_in_secs - minutes * 60;
+		sectors = discid_get_track_length(disc, i);
+		sectors_to_time(sectors, rounded_seconds, time, sizeof(time));
 
-		printf("Track %-2d      : %8d %8d (%02d:%05.2f)\n",
+		printf("Track %-2d      : %8d %8d (%s)\n",
 				i, discid_get_track_offset(disc, i),
-				frames, minutes, seconds);
+				sectors, time);
 	}
 
 	printf("Submit via    : %s\n", discid_get_submission_url(disc));


### PR DESCRIPTION
Example:

```
Length        : 356163 sectors ( 1:19:08.84)
Track 1       :      150    33284 ( 7:23.79)
Track 2       :    33434    43480 ( 9:39.73)
Track 3       :    76914    13717 ( 3:02.89)
Track 4       :    90631    52078 (11:34.37)
Track 5       :   142709    24078 ( 5:21.04)
Track 6       :   166787    33604 ( 7:28.05)
Track 7       :   200391    23830 ( 5:17.73)
Track 8       :   224221    46629 (10:21.72)
Track 9       :   270850    73423 (16:18.97)
Track 10      :   344273    11890 ( 2:38.53)
```
