### PR TITLE
LIB-50: check return value of mb_disc_unix_open

### DIFF
--- a/src/unix.c
+++ b/src/unix.c
@@ -39,10 +39,9 @@ int mb_disc_unix_open(mb_disc_private *disc, const char *device) {
 	if (fd < 0) {
 		snprintf(disc->error_msg, MB_ERROR_MSG_LENGTH,
 			 "cannot open device `%s'", device);
-		return 0;
-	} else {
-		return fd;
 	}
+	/* fd < 0 check needs to be made by caller */
+	return fd;
 }
 
 int mb_disc_unix_read_toc(int fd, mb_disc_private *disc, mb_disc_toc *toc) {
@@ -82,6 +81,9 @@ int mb_disc_read_unportable(mb_disc_private *disc, const char *device,
 	int i;
 
 	fd = mb_disc_unix_open(disc, device);
+	if (fd < 0)
+		return 0;
+
 
 	if ( !mb_disc_unix_read_toc(fd, disc, &toc) )
 		return 0;

--- a/src/unix.h
+++ b/src/unix.h
@@ -54,10 +54,14 @@ LIBDISCID_INTERNAL void mb_disc_unix_read_isrc(int fd, mb_disc_private *disc, in
 /*
  * This function is implemented in unix.c and can be used
  * after the above functions are implemented on the platform.
+ * Returns 1 on success and 0 on failure.
  */
 LIBDISCID_INTERNAL int mb_disc_unix_read_toc(int fd, mb_disc_private *disc, mb_disc_toc *toc);
 
 /*
  * utility function to try opening the device with open()
+ * returns a non-negative file descriptor on success.
+ * On failure a negative integer is returned and error_msg filled
+ * with an appropriate string.
  */
 LIBDISCID_INTERNAL int mb_disc_unix_open(mb_disc_private *disc, const char *device);


### PR DESCRIPTION
This is was caught by drivers on most platforms, but not Solaris.
Invalid device names could lead to segmentation faults on Solaris.

See:
http://tickets.musicbrainz.org/browse/LIB-50
