### PR TITLE
LIB-51: darwin: don't close the fd after toc read

### DIFF
--- a/src/disc_darwin.c
+++ b/src/disc_darwin.c
@@ -222,7 +222,6 @@ int mb_disc_unix_read_toc_header(int fd, mb_disc_toc *mb_toc) {
 	mb_toc->first_track_num = min_track;
 	mb_toc->last_track_num = max_track;
 
-	close(fd);
 	free(toc.buffer);
 
 	return 1;


### PR DESCRIPTION
This obviously broke all later disc reads,including MCN and ISRCs.

This was introduced in fe2d1fb955,but not at all easy to see in the diff.

The corresponding issue is:
http://tickets.musicbrainz.org/browse/LIB-51
