### PR TITLE
Fixed compiler warnings due to unsafe type conversions.

### DIFF
--- a/src/disc_win32.c
+++ b/src/disc_win32.c
@@ -52,8 +52,9 @@ static int AddressToSectors(UCHAR address[4])
 static HANDLE create_device_handle(mb_disc_private *disc, const char *device)
 {
 	HANDLE hDevice;
-	char filename[128], *colon;
-	int len;
+	char filename[128];
+	const char* colon;
+	size_t len;
 
 	strcpy(filename, "\\\\.\\");
 	len = strlen(device);

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -201,9 +201,9 @@ void sha_init(SHA_INFO *sha_info)
 
 /* update the SHA digest */
 
-void sha_update(SHA_INFO *sha_info, SHA_BYTE *buffer, int count)
+void sha_update(SHA_INFO *sha_info, SHA_BYTE *buffer, size_t count)
 {
-    int i;
+    size_t i;
     SHA_LONG clo;
 
     clo = T32(sha_info->count_lo + ((SHA_LONG) count << 3));
@@ -293,7 +293,7 @@ void sha_final(unsigned char digest[20], SHA_INFO *sha_info)
 
 void sha_stream(unsigned char digest[20], SHA_INFO *sha_info, FILE *fin)
 {
-    int i;
+    size_t i;
     SHA_BYTE data[BLOCK_SIZE];
 
     sha_init(sha_info);

--- a/src/sha1.h
+++ b/src/sha1.h
@@ -23,11 +23,11 @@ typedef struct {
     SHA_LONG digest[5];		/* message digest */
     SHA_LONG count_lo, count_hi;	/* 64-bit bit count */
     SHA_BYTE data[SHA_BLOCKSIZE];	/* SHA data buffer */
-    int local;			/* unprocessed amount in data */
+    size_t local;			/* unprocessed amount in data */
 } SHA_INFO;
 
 LIBDISCID_INTERNAL void sha_init(SHA_INFO *);
-LIBDISCID_INTERNAL void sha_update(SHA_INFO *, SHA_BYTE *, int);
+LIBDISCID_INTERNAL void sha_update(SHA_INFO *, SHA_BYTE *, size_t);
 LIBDISCID_INTERNAL void sha_final(unsigned char [20], SHA_INFO *);
 
 LIBDISCID_INTERNAL void sha_stream(unsigned char [20], SHA_INFO *, FILE *);


### PR DESCRIPTION
The type conversions fixed here cause warning when building in Visual Studio as 64bit, but are potential error sources on other platforms as well.
