### PR TITLE
LIB-55: Allow using device numbers on Windows.

### DIFF
--- a/src/disc_win32.c
+++ b/src/disc_win32.c
@@ -144,7 +144,7 @@ int get_nth_device(int number, char* device, int device_length) {
 
 				if (counter == number)
 				{
-					strncpy(tmpDevice, device, MAX_DEV_LEN);
+					strncpy(device, tmpDevice, device_length);
 					return TRUE;
 				}
 			}


### PR DESCRIPTION
@jonnyjd: Made a new PR against master. A wrong drive number will now lead to an error instead of falling back to `MB_DEFAULT_DEVICE`.

This PR replaces https://github.com/phw/libdiscid/pull/1

EDIT by JonnyJD:
tracked in http://tickets.musicbrainz.org/browse/LIB-55
