### PR TITLE
LIB-56: allow using device numbers one linux

### DIFF
--- a/src/disc_linux.c
+++ b/src/disc_linux.c
@@ -74,9 +74,6 @@ static int get_device(int number, char *device, int device_len) {
 		/* skip to line containing device names */
 		do {
 			if (getline(&lineptr, &bufflen, proc_file) < 0) {
-				/* no devices detected at all
-				 * get one for the error message later on
-				 */
 				return 0;
 			}
 		} while (strstr(lineptr, "drive name:") == NULL);


### PR DESCRIPTION
Numbers start with 1 and /dev/cdrom is still preferred.

This is tracked in http://tickets.musicbrainz.org/browse/LIB-56.
