### PR TITLE
Minor fixes to get_device().

### DIFF
--- a/src/disc_linux.c
+++ b/src/disc_linux.c
@@ -101,8 +101,8 @@ static int get_device(int number, char *device, int device_len) {
 		}
 
 		/* trim the trailing \n for the last entry = first device */
-		if (default_device[strlen(default_device)-1] == '\n') {
-			default_device[strlen(default_device)-1] = '\0';
+		if (return_value && device[strlen(device)-1] == '\n') {
+			device[strlen(device)-1] = '\0';
 		}
 		free(lineptr);
 		fclose(proc_file);


### PR DESCRIPTION
This corrects references to default_device (should be referring to the device parameter instead), and also avoids looking for a newline unless a value was set (otherwise, if no value was found, and the device parameter contained the empty string, it would access the byte before the device parameter).