### PR TITLE
Unix file descriptor leak

### DIFF
--- a/src/disc_solaris.c
+++ b/src/disc_solaris.c
@@ -70,13 +70,13 @@ int mb_disc_unix_read_toc_entry(int fd, int track_num, mb_disc_toc_track *track)
 	ret = ioctl(fd, CDROMREADTOCENTRY, &te);
 
 	if ( ret < 0 )
-		return ret; /* error */
+		return 0; /* error */
 
 	assert( te.cdte_format == CDROM_LBA );
 	track->address = te.cdte_addr.lba;
 	track->control = te.cdte_ctrl;
 
-	return ret;
+	return 1;
 }
 
 void mb_disc_unix_read_mcn(int fd, mb_disc_private *disc) {


### PR DESCRIPTION
Currently, mb_disc_unix_read_disc() will leak the file descriptor when mb_disc_load_toc() reports an error. This fixes that, moving all close()s of the descriptor into mb_disc_unix_read_disc() in the process.

This also checks the return code for mb_disc_unix_read_toc_entry(), which was previously ignored. The Solaris implementation needed adjusting, because unlike the others, it did not return 0 on failure.