### PR TITLE
Fixes build issue when using Visual Studio 2015 build tools

### DIFF
--- a/examples/discid.c
+++ b/examples/discid.c
@@ -21,8 +21,10 @@
 
 --------------------------------------------------------------------------- */
 #ifdef _MSC_VER
-#define snprintf _snprintf
-#define _CRT_SECURE_NO_WARNINGS
+	#define _CRT_SECURE_NO_WARNINGS
+	#if (_MSC_VER < 1900)
+		#define snprintf _snprintf
+	#endif
 #endif
 
 #include <stdio.h>

--- a/src/disc_win32.c
+++ b/src/disc_win32.c
@@ -21,8 +21,10 @@
 ----------------------------------------------------------------------------*/
 
 #ifdef _MSC_VER
-#define snprintf _snprintf
-#define _CRT_SECURE_NO_WARNINGS
+	#define _CRT_SECURE_NO_WARNINGS
+	#if (_MSC_VER < 1900)
+		#define snprintf _snprintf
+	#endif
 #endif
 
 #include <windows.h>

--- a/src/toc.c
+++ b/src/toc.c
@@ -21,9 +21,12 @@
 --------------------------------------------------------------------------- */
 
 #ifdef _MSC_VER
-#define snprintf _snprintf
-#define _CRT_SECURE_NO_WARNINGS
+	#define _CRT_SECURE_NO_WARNINGS
+	#if (_MSC_VER < 1900)
+		#define snprintf _snprintf
+	#endif
 #endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
I've tested this against Visual Studio 2013 and 2015 and it builds on both. This bug stems from the fact that it is no longer necessary to define _snprintf_ in VS2015.