### PR TITLE
LIB-66: Fix compilation on Debian/kFreeBSD.

### DIFF
--- a/src/disc_bsd.c
+++ b/src/disc_bsd.c
@@ -32,7 +32,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 #include <netinet/in.h> /* for ntohl() */
 #else
 #include <util.h> /* for getrawpartition() */
@@ -44,10 +44,12 @@
 #define MAX_DEV_LEN 15
 
 static int get_device(int n, char* device_name, size_t device_name_length) {
-#if !defined(__FreeBSD__) /* /dev/rcdNX, where X is the letter for the raw partition */
-	snprintf(device_name, device_name_length, "/dev/rcd%d%c", n - 1, 'a' + getrawpartition());
-#else /* on FreeBSD it's just /dev/cdN */
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+	/* on FreeBSD it's just /dev/cdN */
 	snprintf(device_name, device_name_length, "/dev/cd%d", n - 1);
+#else
+	/* On NetBSD and OpenBSD, it's /dev/rcdNX, where X is the letter for the raw partition */
+	snprintf(device_name, device_name_length, "/dev/rcd%d%c", n - 1, 'a' + getrawpartition());
 #endif
 	return mb_disc_unix_exists(device_name);
 }


### PR DESCRIPTION
It only uses the FreeBSD kernel, so it does not define __FreeBSD__ (it defines __FreeBSD_kernel__ instead).
Note that the CD ioctls do not seem to work properly on this system (they return successfully, but only see
a single non-audio track before the leadout), so while the library should compile now, it doesn't actually
_work_.