### PR TITLE
Build Windows and macOS binaries

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ package win:
       - COPYING
       - README
       - ChangeLog
-    expire_in: 1d
+    expire_in: 30d
   tags:
     - winxp
 
@@ -40,6 +40,6 @@ package osx:
       - COPYING
       - README
       - ChangeLog
-    expire_in: 1d
+    expire_in: 30d
   tags:
     - osx

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,45 @@
+stages:
+  - package
+
+package win:
+  stage: package
+  script:
+    - call "C:\\Program Files\\Microsoft Visual Studio 9.0\\Common7\\Tools\\vsvars32.bat"
+    - cmake -DCMAKE_BUILD_TYPE=Release -G "NMake Makefiles" .
+    - nmake
+  artifacts:
+    paths:
+      - discid.exe
+      - discid.exe.manifest
+      - discisrc.exe
+      - discid.exe.manifest
+      - discid.dll
+      - discid.dll.manifest
+      - discid.lib
+      - discid.exp
+      - include/discid/*.h
+      - COPYING
+      - README
+      - ChangeLog
+    expire_in: 1d
+  tags:
+    - winxp
+
+package osx:
+  stage: package
+  script:
+    - export SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.6.sdk
+    - cmake -DCMAKE_BUILD_TYPE=Release .
+    - make
+    - cp -L libdiscid.0.dylib libdiscid.0.dylib.tmp
+    - mv libdiscid.0.dylib.tmp libdiscid.0.dylib
+  artifacts:
+    paths:
+      - libdiscid.0.dylib
+      - include/discid/*.h
+      - COPYING
+      - README
+      - ChangeLog
+    expire_in: 1d
+  tags:
+    - osx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,15 +74,15 @@ ELSE()
 ENDIF()
 
 # choose platform dependent source files
-IF(libdiscid_OS EQUAL "win32")
+IF(libdiscid_OS STREQUAL "win32")
     SET(libdiscid_OSDEP_SRCS src/toc.c src/disc_win32.c)
     SET(libdiscid_RCS ${CMAKE_CURRENT_BINARY_DIR}/versioninfo.rc)
-ELSEIF(libdiscid_OS EQUAL "generic")
+ELSEIF(libdiscid_OS STREQUAL "generic")
     SET(libdiscid_OSDEP_SRCS src/disc_${libdiscid_OS}.c)
 ELSE()
     # unix platforms are the standard/default case
     SET(libdiscid_OSDEP_SRCS src/toc.c src/unix.c src/disc_${libdiscid_OS}.c)
-    IF(libdiscid_OS EQUAL "darwin") # Extra libraries needed
+    IF(libdiscid_OS STREQUAL "darwin") # Extra libraries needed
         FIND_LIBRARY(COREFOUNDATION_LIBRARY CoreFoundation)
         SET(libdiscid_OSDEP_LIBS ${COREFOUNDATION_LIBRARY} IOKit)
     ENDIF()


### PR DESCRIPTION
I have Windows and macOS build machines for AcoustID projects that are also used for Picard, so I thought they could be used for libdiscid as well, since there are no binaries for 0.6.2 currently. These are in a different structure than the older binaries on mb.org, I though this is more useful. There are also only 64-bit macOS builds. Pretty much nobody supports older architectures.

I'm not sure if this is something you want, but if yes, please merge this and I'll setup a mirror here:

https://code.oxygene.sk/musicbrainz/libdiscid/pipelines