### PR TITLE
Modernize packaging and releasing with Github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,21 @@ jobs:
         make
         make check
 
+  package-source:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Make source tarball
+      run: |
+        TAG=$(git describe)
+        mkdir artifacts/
+        git archive --format=tar.gz --prefix=libdiscid-$TAG/ $TAG > artifacts/libdiscid-$TAG.tar.gz
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: libdiscid-source
+        path: artifacts/
+
   package-windows:
     runs-on: windows-2019
     strategy:
@@ -93,6 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
+    - package-source
     - package-macos
     - package-windows
     steps:
@@ -114,10 +130,10 @@ jobs:
       with:
         name: libdiscid-macos-x86_64
         path: artifacts/libdiscid-macos-${{ env.VERSION }}-x86_64/
-    - name: Make source tarball
-      run: |
-        mkdir artifacts/release/
-        git archive --format=tar.gz --prefix=libdiscid-$TAG/ $TAG > artifacts/release/libdiscid-$VERSION.tar.gz
+    - uses: actions/download-artifact@v1
+      with:
+        name: libdiscid-source
+        path: artifacts/release/
     - name: Make zips
       run: |
         cd artifacts/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,19 +134,19 @@ jobs:
       run: |
         TAG=${GITHUB_REF##*/}
         echo "VERSION=$(echo $TAG | sed 's/^v//')" >> $GITHUB_ENV
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v3
       with:
         name: libdiscid-windows-Win32
         path: artifacts/libdiscid-windows-${{ env.VERSION }}-win32/
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v3
       with:
         name: libdiscid-windows-x64
         path: artifacts/libdiscid-windows-${{ env.VERSION }}-win64/
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v3
       with:
         name: libdiscid-macos-x86_64
         path: artifacts/libdiscid-macos-${{ env.VERSION }}-x86_64/
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v3
       with:
         name: libdiscid-source
         path: artifacts/release/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         make check
 
   package-windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         generator:
@@ -65,7 +65,7 @@ jobs:
         # .\Release\test_read_full.exe
 
   package-macos:
-    runs-on: macos-latest
+    runs-on: macos-11
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.10
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Build and test
       run: |
         mkdir build
@@ -23,17 +23,34 @@ jobs:
   package-source:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        path: libdiscid
+        fetch-depth: 0
+    - name: Set version
+      run: |
+        cd libdiscid
+        TAG=$(git describe)
+        echo "VERSION=$(echo $TAG | sed 's/^v//')" >> $GITHUB_ENV
+    - name: Autotools
+      run: |
+        cd libdiscid
+        ./autogen.sh
     - name: Make source tarball
       run: |
-        TAG=$(git describe)
         mkdir artifacts/
-        git archive --format=tar.gz --prefix=libdiscid-$TAG/ $TAG > artifacts/libdiscid-$TAG.tar.gz
+        rm -rf libdiscid/.git
+        rm -rf libdiscid/.github
+        rm -rf libdiscid/.gitattributes
+        rm -rf libdiscid/.gitignore
+        rm -rf libdiscid/autom4te.cache
+        mv libdiscid libdiscid-$VERSION
+        tar czf artifacts/libdiscid-$VERSION.tar.gz libdiscid-$VERSION/
     - name: Archive production artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: libdiscid-source
-        path: artifacts/
+        path: artifacts/libdiscid-${{ env.VERSION }}.tar.gz
 
   package-windows:
     runs-on: windows-2019
@@ -45,7 +62,7 @@ jobs:
         - Win32
         - x64
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Setup cmake
       run: |
         mkdir build
@@ -66,7 +83,7 @@ jobs:
         cp ..\README artifacts
         cp ..\ChangeLog artifacts
     - name: Archive production artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: libdiscid-windows-${{ matrix.architecture }}
         path: build/artifacts/
@@ -84,7 +101,7 @@ jobs:
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.10
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Build
       run: |
         mkdir build
@@ -99,7 +116,7 @@ jobs:
         cp -Rv include artifacts/
         cp -v ../COPYING ../README ../ChangeLog artifacts
     - name: Archive production artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: libdiscid-macos-x86_64
         path: build/artifacts
@@ -112,12 +129,11 @@ jobs:
     - package-macos
     - package-windows
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set version
       run: |
         TAG=${GITHUB_REF##*/}
-        echo "::set-env name=TAG::$TAG"
-        echo "::set-env name=VERSION::$(echo $TAG | sed 's/^v//')"
+        echo "VERSION=$(echo $TAG | sed 's/^v//')" >> $GITHUB_ENV
     - uses: actions/download-artifact@v1
       with:
         name: libdiscid-windows-Win32

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ define(MINOR, 6)
 define(PATCH, 2)
 # currently the sole purpose of the project is the library,
 # so we use the library version also as project version
-AC_INIT(libdiscid, MAJOR.MINOR.PATCH)
+AC_INIT([libdiscid],[MAJOR.MINOR.PATCH])
 
 AC_CONFIG_SRCDIR([src/disc.c])
 AC_CONFIG_HEADERS([config.h])
@@ -79,7 +79,7 @@ LT_LANG([Windows Resource])
 
 dnl Checks for programs.
 AC_PROG_CC
-AM_PROG_LIBTOOL
+LT_INIT
 AC_PROG_INSTALL
 
 dnl Test endianness and size of a long; required for the SHA1 implementation.
@@ -106,6 +106,7 @@ m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 AC_CHECK_HEADER([musicbrainz5/mb5_c.h], [have_mb5=yes])
 AM_CONDITIONAL([HAVE_MUSICBRAINZ5], [test x${have_mb5} = xyes])
 
-AC_OUTPUT([
+AC_CONFIG_FILES([
   Makefile libdiscid.pc versioninfo.rc Doxyfile include/discid/discid.h
 ])
+AC_OUTPUT


### PR DESCRIPTION
- Build a proper source artifact
- Updated to latest action versions and remove deprecated set-env call
- Fix windows builds