### PR TITLE
Sign Windows binaries with Azure Trusted Signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: windows-2019
     env:
       GENERATOR: Visual Studio 16 2019
+      CODESIGN: ${{ !!secrets.AZURE_CERT_PROFILE_NAME }}
     steps:
     - uses: actions/checkout@v3
     - name: Prepare package
@@ -67,6 +68,21 @@ jobs:
         cp .\Release\* ..\artifacts\$env:ARCH
       env:
         ARCH: Win32
+    - name: Sign generated DLLs
+      uses: azure/trusted-signing-action@v0.5.0
+      if: env.CODESIGN == 'true'
+      with:
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+        endpoint: ${{ secrets.AZURE_ENDPOINT }}
+        trusted-signing-account-name: ${{ secrets.AZURE_CODE_SIGNING_NAME }}
+        certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+        files-folder: artifacts
+        files-folder-filter: exe,dll
+        files-folder-recurse: true
+        timestamp-rfc3161: http://timestamp.acs.microsoft.com
+        timestamp-digest: SHA256
     - name: Archive production artifacts
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Enable signing the Windows binaries with Azure Trusted Signing.

See also related change for Picard [2557](https://github.com/metabrainz/picard/pull/2557)