### PR TITLE
Use HTTPS for MusicBrainz URLs

### DIFF
--- a/include/discid/discid_private.h
+++ b/include/discid/discid_private.h
@@ -52,10 +52,10 @@
 #define MB_MAX_URL_LENGTH		(MB_URL_PREFIX_LENGTH + MB_DISC_ID_LENGTH + MB_TOC_STRING_LENGTH)
 
 /* The URL that can be used for submitting DiscIDs (no parameters yet) */
-#define MB_SUBMISSION_URL		"http://musicbrainz.org/cdtoc/attach"
+#define MB_SUBMISSION_URL		"https://musicbrainz.org/cdtoc/attach"
 
 /* The URL that can be used for retrieving XML for a CD */
-#define MB_WEBSERVICE_URL		"http://musicbrainz.org/ws/1/release"
+#define MB_WEBSERVICE_URL		"https://musicbrainz.org/ws/1/release"
 
 /* Maximum length of a Media Catalogue Number string */
 #define MCN_STR_LENGTH		13

--- a/test/test_put.c
+++ b/test/test_put.c
@@ -100,7 +100,7 @@ int main(int argc, char *argv[]) {
 
 	/* MusicBrainz web submit URL */
 	announce("discid_get_submission_url");
-	expected = "http://musicbrainz.org/cdtoc/attach?id=xUp1F2NkfP8s8jaeFn_Av3jNEI4-&tracks=22&toc=1+22+303602+150+9700+25887+39297+53795+63735+77517+94877+107270+123552+135522+148422+161197+174790+192022+205545+218010+228700+239590+255470+266932+288750";
+	expected = "https://musicbrainz.org/cdtoc/attach?id=xUp1F2NkfP8s8jaeFn_Av3jNEI4-&tracks=22&toc=1+22+303602+150+9700+25887+39297+53795+63735+77517+94877+107270+123552+135522+148422+161197+174790+192022+205545+218010+228700+239590+255470+266932+288750";
 	evaluate(equal_str(discid_get_submission_url(d), expected));
 
 	announce("discid_get_error_msg");


### PR DESCRIPTION
Since these redirect to HTTPS anyway, why not do it explicitly and maybe prevent some machine in the middle attacks.