### PR TITLE
CI build with both autotools and cmake, compare output of generated files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
         make
         make check
     - name: Build and test (autotools)
+      if: runner.os == 'linux'
       run: |
         ./autogen.sh
         mkdir _build_autotools
@@ -28,6 +29,7 @@ jobs:
         make
         make check
     - name: Verify identical build output of build systems
+      if: runner.os == 'linux'
       run: |
         diff _build_cmake/include/discid/discid.h _build_autotools/include/discid/discid.h
         diff _build_cmake/libdiscid.pc _build_autotools/libdiscid.pc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,26 @@ jobs:
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v7
-    - name: Build and test
+    - name: Build and test (cmake)
       run: |
-        mkdir build
-        cd build
+        mkdir _build_cmake
+        cd _build_cmake
         cmake ..
         make
         make check
+    - name: Build and test (autotools)
+      run: |
+        ./autogen.sh
+        mkdir _build_autotools
+        cd _build_autotools
+        ../configure
+        make
+        make check
+    - name: Verify identical build output of build systems
+      run: |
+        diff _build_cmake/include/discid/discid.h _build_autotools/include/discid/discid.h
+        diff _build_cmake/libdiscid.pc _build_autotools/libdiscid.pc
+        diff _build_cmake/versioninfo.rc _build_autotools/versioninfo.rc
 
   package-source:
     runs-on: ubuntu-latest


### PR DESCRIPTION
While autotools might be removed in the future, as long as it is supported it should be ensured it works, including output of files generated from templates (variable substitution).