### PR TITLE
Fix strncpy truncation compiler warning

### DIFF
--- a/src/disc_bsd.c
+++ b/src/disc_bsd.c
@@ -122,12 +122,12 @@ void mb_disc_unix_read_mcn(int fd, mb_disc_private *disc) {
 	if ( ioctl(fd, CDIOCREADSUBCHANNEL, &rsc) < 0 )
 		perror ("Warning: Unable to read the disc's media catalog number");
 	else {
-		if (sci.what.media_catalog.mc_valid)
-			strncpy( disc->mcn,
-				 (const char *) sci.what.media_catalog.mc_number,
-				 MCN_STR_LENGTH );
-		else
-			memset( disc->mcn, 0, MCN_STR_LENGTH );
+		if (sci.what.media_catalog.mc_valid) {
+			memcpy(disc->mcn, sci.what.media_catalog.mc_number, MCN_STR_LENGTH);
+			disc->mcn[MCN_STR_LENGTH] = '\0';
+		} else {
+			memset(disc->mcn, 0, MCN_STR_LENGTH+1);
+		}
 	}
 }
 
@@ -146,12 +146,14 @@ void mb_disc_unix_read_isrc(int fd, mb_disc_private *disc, int track_num) {
 	if ( ioctl(fd, CDIOCREADSUBCHANNEL, &rsc) < 0 )
 		perror ("Warning: Unable to read track info (ISRC)");
 	else {
-		if (sci.what.track_info.ti_valid)
-			strncpy( disc->isrc[track_num],
-				 (const char *) sci.what.track_info.ti_number,
-				 ISRC_STR_LENGTH );
-		else
-			memset( disc->isrc[track_num], 0, ISRC_STR_LENGTH );
+		if (sci.what.track_info.ti_valid) {
+			memcpy(disc->isrc[track_num],
+			       sci.what.track_info.ti_number,
+			       ISRC_STR_LENGTH);
+			disc->isrc[track_num][ISRC_STR_LENGTH] = '\0';
+		} else {
+			memset(disc->isrc[track_num], 0, ISRC_STR_LENGTH+1);
+		}
 	}
 }
 

--- a/src/disc_darwin.c
+++ b/src/disc_darwin.c
@@ -124,7 +124,8 @@ void mb_disc_unix_read_mcn(int fd, mb_disc_private *disc)
     if(ioctl(fd, DKIOCCDREADMCN, &cd_read_mcn) == -1) {
         fprintf(stderr, "Warning: Unable to read the disc's media catalog number.\n");
     } else {
-        strncpy( disc->mcn, cd_read_mcn.mcn, MCN_STR_LENGTH );
+        memcpy(disc->mcn, cd_read_mcn.mcn, MCN_STR_LENGTH);
+        disc->mcn[MCN_STR_LENGTH] = '\0';
     }
 }
 
@@ -138,7 +139,8 @@ void mb_disc_unix_read_isrc(int fd, mb_disc_private *disc, int track)
         fprintf(stderr, "Warning: Unable to read the international standard recording code (ISRC) for track %i\n", track);
         return;
     } else {
-        strncpy( disc->isrc[track], cd_read_isrc.isrc, ISRC_STR_LENGTH );
+        memcpy(disc->isrc[track], cd_read_isrc.isrc, ISRC_STR_LENGTH);
+        disc->isrc[track][ISRC_STR_LENGTH] = '\0';
     }
 }
 

--- a/src/disc_linux.c
+++ b/src/disc_linux.c
@@ -164,9 +164,8 @@ void mb_disc_unix_read_mcn(int fd, mb_disc_private *disc) {
 	if(ioctl(fd, CDROM_GET_MCN, &mcn) == -1) {
 		fprintf(stderr, "Warning: Unable to read the disc's media catalog number.\n");
 	} else {
-		strncpy( disc->mcn,
-				(const char *)mcn.medium_catalog_number,
-				MCN_STR_LENGTH );
+		memcpy(disc->mcn, mcn.medium_catalog_number, MCN_STR_LENGTH);
+		disc->mcn[MCN_STR_LENGTH] = '\0';
 	}
 }
 
@@ -235,8 +234,8 @@ void mb_disc_unix_read_isrc(int fd, mb_disc_private *disc, int track_num) {
 		for (i = 0; i < ISRC_STR_LENGTH; i++) {
 			buffer[i] = data[9 + i];
 		}
-		buffer[ISRC_STR_LENGTH] = 0;
-		strncpy(disc->isrc[track_num], buffer, ISRC_STR_LENGTH);
+		buffer[ISRC_STR_LENGTH] = '\0';
+		memcpy(disc->isrc[track_num], buffer, ISRC_STR_LENGTH+1);
 	}
 	/* data[21:23] = zero, AFRAME, reserved */
 }

--- a/src/disc_win32.c
+++ b/src/disc_win32.c
@@ -101,8 +101,8 @@ static void read_disc_mcn(HANDLE hDevice, mb_disc_private *disc) {
 	if (bResult == FALSE) {
 		fprintf(stderr, "Warning: Unable to read the disc's media catalog number.\n");
 	} else {
-		strncpy(disc->mcn, (char *) data.MediaCatalog.MediaCatalog,
-			MCN_STR_LENGTH);
+		memcpy(disc->mcn, data.MediaCatalog.MediaCatalog, MCN_STR_LENGTH);
+		disc->mcn[MCN_STR_LENGTH] = '\0';
 	}
 }
 
@@ -121,8 +121,8 @@ static void read_disc_isrc(HANDLE hDevice, mb_disc_private *disc, int track) {
 	if (bResult == FALSE) {
 		fprintf(stderr, "Warning: Unable to read the international standard recording code (ISRC) for track %i\n", track);
 	} else {
-		strncpy(disc->isrc[track], (char *) data.TrackIsrc.TrackIsrc,
-			ISRC_STR_LENGTH);
+		memcpy(disc->isrc[track], data.TrackIsrc.TrackIsrc, ISRC_STR_LENGTH);
+		disc->isrc[track][ISRC_STR_LENGTH] = '\0';
 	}
 }
 


### PR DESCRIPTION
Use memcpy instead for ISRC / MCN copying and explicitly ensure null termination of resulting strings.