### PR TITLE
Provide Windows ARM64 binary builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,6 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
     needs:
     - test
     - package-source
@@ -193,9 +192,12 @@ jobs:
     - package-windows
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 300
+        fetch-tags: true
     - name: Set version
       run: |
-        TAG=${GITHUB_REF##*/}
+        TAG=$(git describe)
         echo "VERSION=$(echo $TAG | sed 's/^v//')" >> $GITHUB_ENV
     - uses: actions/download-artifact@v7
       with:
@@ -229,8 +231,14 @@ jobs:
       run: |
         cd artifacts/release/
         sha256sum * > SHA256SUMS
+    - name: Release artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: release-packages
+        path: artifacts/release
     - name: Release
       uses: softprops/action-gh-release@v3
+      if: startsWith(github.ref, 'refs/tags/v')
       with:
         files: artifacts/release/*
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,14 @@ jobs:
         path: libdiscid-*.tar.gz
 
   package-windows:
-    runs-on: windows-2022
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [windows-2022]
         arch: [x64, Win32]
+        include:
+        - os: windows-11-arm
+          arch: arm64
     permissions:
       id-token: write
     env:
@@ -200,6 +204,10 @@ jobs:
     - uses: actions/download-artifact@v7
       with:
         name: libdiscid-windows-Win32
+        path: artifacts/libdiscid-${{ env.VERSION }}-win/
+    - uses: actions/download-artifact@v7
+      with:
+        name: libdiscid-windows-arm64
         path: artifacts/libdiscid-${{ env.VERSION }}-win/
     - uses: actions/download-artifact@v7
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,11 +51,15 @@ jobs:
 
   package-windows:
     runs-on: windows-2022
+    strategy:
+      matrix:
+        arch: [x64, Win32]
     permissions:
       id-token: write
     env:
       GENERATOR: Visual Studio 17 2022
       CODESIGN: ${{ !!secrets.AZURE_CERT_PROFILE_NAME }}
+      ARCH: ${{ matrix.arch }}
     steps:
     - uses: actions/checkout@v7
     - name: Prepare package
@@ -64,27 +68,15 @@ jobs:
         cp .\COPYING artifacts
         cp .\README artifacts
         cp .\ChangeLog artifacts
-    - name: Build x64
+    - name: Build ${{ matrix.arch }}
       run: |
-        mkdir _build_$env:ARCH
-        cd _build_$env:ARCH
+        mkdir _build
+        cd _build
         cmake -G $env:GENERATOR -A $env:ARCH ..
         cmake --build . --config Release
         mkdir ..\artifacts\$env:ARCH
         cp .\Release\* ..\artifacts\$env:ARCH
         cp -R .\include ..\artifacts
-      env:
-        ARCH: x64
-    - name: Build Win32
-      run: |
-        mkdir _build_$env:ARCH
-        cd _build_$env:ARCH
-        cmake -G $env:GENERATOR -A $env:ARCH ..
-        cmake --build . --config Release
-        mkdir ..\artifacts\$env:ARCH
-        cp .\Release\* ..\artifacts\$env:ARCH
-      env:
-        ARCH: Win32
     - name: Azure login
       uses: azure/login@v3.0.0
       if: env.CODESIGN == 'true'
@@ -108,17 +100,11 @@ jobs:
     - name: Archive production artifacts
       uses: actions/upload-artifact@v7
       with:
-        name: libdiscid-windows
+        name: libdiscid-windows-${{ matrix.arch }}
         path: artifacts/
-    - name: Test x64
+    - name: Test ${{ matrix.arch }}
       run: |
-        cd _build_x64
-        cmake --build . --config Release --target test_core test_put test_read test_read_full
-        .\Release\test_core.exe
-        .\Release\test_put.exe
-    - name: Test Win32
-      run: |
-        cd _build_Win32
+        cd _build
         cmake --build . --config Release --target test_core test_put test_read test_read_full
         .\Release\test_core.exe
         .\Release\test_put.exe
@@ -209,7 +195,11 @@ jobs:
         echo "VERSION=$(echo $TAG | sed 's/^v//')" >> $GITHUB_ENV
     - uses: actions/download-artifact@v7
       with:
-        name: libdiscid-windows
+        name: libdiscid-windows-x64
+        path: artifacts/libdiscid-${{ env.VERSION }}-win/
+    - uses: actions/download-artifact@v7
+      with:
+        name: libdiscid-windows-Win32
         path: artifacts/libdiscid-${{ env.VERSION }}-win/
     - uses: actions/download-artifact@v7
       with:

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ libdiscid-unreleased
 - Mac: Fix compiler warning about deprecated use of IOMasterPort
 - Fix compiler warnings about use of strncpy
 - Consistently use CRLF for newlines in versioninfo.rc
+- Provide Windows ARM64 binary builds
 
 libdiscid-0.6.5:
 


### PR DESCRIPTION
Extend Github Actions CI to also build on Windows ARM64 and include the binaries in the release package.

As part of this:

- Turn the windows build into a matrix build
- Always run the release task and generate an artifact with the result. But limit actual Github release creation to release tags only.